### PR TITLE
Comment out 'set-but-not-used' variables.

### DIFF
--- a/src/physics/G4S1Light.cc
+++ b/src/physics/G4S1Light.cc
@@ -1135,7 +1135,7 @@ G4double GetLiquidElectronDriftSpeed(G4double tempinput, G4double efieldinput,
     thri=58.3785811395493,
     thrj=201512.080026704;
   G4double y1=0,y2=0,f1=0,f2=0,f3=0,edrift=0,
-    t1=0,t2=0,frac=0,slope=0,intercept=0;
+    t1=0,t2=0,slope=0,intercept=0;
 
   //Equations defined
   f1=onea/(1+exp(-(efieldinput-oneb)/onec))+oned/
@@ -1174,7 +1174,7 @@ G4double GetLiquidElectronDriftSpeed(G4double tempinput, G4double efieldinput,
   else if (tempinput == 200.0) edrift = f2;
   else if (tempinput == 230.0) edrift = f3;
   else { //Linear interpolation
-    frac=(tempinput-t1)/(t2-t1);
+//    double frac=(tempinput-t1)/(t2-t1);
     slope = (y1-y2)/(t1-t2);
     intercept=y1-slope*t1;
     edrift=slope*tempinput+intercept;

--- a/src/physics/GLG4Scint.cc
+++ b/src/physics/GLG4Scint.cc
@@ -269,7 +269,7 @@ GLG4Scint::PostPostStepDoIt(const G4Track& aTrack, const G4Step& aStep) {
     G4int numSecondaries;
     G4double weight;
     //G4double reemissionProb = 0;
-    G4int numComponents = -1;
+    //G4int numComponents = -1;
     //G4int absorberIndex = -1;
 
     if (flagReemission) {
@@ -279,7 +279,7 @@ GLG4Scint::PostPostStepDoIt(const G4Track& aTrack, const G4Step& aStep) {
       // Check if there are multiple components
       if (mpt_scint->ConstPropertyExists("COMPONENTS")) {
         RAT::Log::Die("GLG4Scint: COMPONENTS not yet implemented");
-        numComponents = (G4int) mpt_scint->GetConstProperty("NUM_COMP");
+        //numComponents = (G4int) mpt_scint->GetConstProperty("NUM_COMP");
       }
 
       G4MaterialPropertyVector* mpv_scint_reemission =

--- a/src/physics/WlsScintillation.cc
+++ b/src/physics/WlsScintillation.cc
@@ -296,9 +296,9 @@ WlsScintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep)
 
         // Birks law saturation:
 
-        G4double constBirks = 0.0;
+        //G4double constBirks = 0.0;
 
-        constBirks = aMaterial->GetIonisation()->GetBirksConstant();
+        //constBirks = aMaterial->GetIonisation()->GetBirksConstant();
 
         G4double MeanNumberOfPhotons;
 


### PR DESCRIPTION
Under GCC >=4.6, compilation fails due to several 'set but not used' warnings (-Werror turned on).
