### PR TITLE
Add EGADS attenuation measurements

### DIFF
--- a/data/ELEMENTS.ratdb
+++ b/data/ELEMENTS.ratdb
@@ -403,3 +403,23 @@ z: 39,
 a:88.9d,
 }
 
+{
+name: "ELEMENT",
+index: "Gadolinium",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+SYMBOL: "Gd",
+z: 64,
+a: 157.25d,
+}
+
+{
+name: "ELEMENT",
+index: "Sulfur",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+SYMBOL: "S",
+z: 16,
+a: 96.18d,
+}
+

--- a/data/MATERIALS.ratdb
+++ b/data/MATERIALS.ratdb
@@ -41,6 +41,29 @@ elements: ["Hydrogen", "Oxygen",],
 elemprop: [0.1119d, 0.8881d],
 }
 
+{
+name: "MATERIAL",
+index: "gd_sulfate",
+valid_begin : [0, 0],
+valid_end : [0, 0],
+density: 3.01d,
+nelements: 3,
+nmaterials: 0,
+elements: ["Gadolinium", "Sulfur", "Oxygen",],
+elemprop: [0.5218d, 0.1596d, 0.3186d],
+}
+
+{
+name: "MATERIAL",
+index: "water_egads_gd_sulfate_0p2",
+valid_begin : [0, 0],
+valid_end : [0, 0],
+density: 1.0d,
+nelements: 0,
+nmaterials: 2,
+materials: ["water", "gd_sulfate",],
+matprop: [0.998d, 0.002d],
+}
  
 {
 name: "MATERIAL",

--- a/data/OPTICS.ratdb
+++ b/data/OPTICS.ratdb
@@ -51,6 +51,25 @@ RSLENGTH_value2: [10.0d3, 10.0d3, 10.0d3, ],
 PROPERTY_LIST: ["NEUTRON_CAPTURE_TIME", "NEUTRON_SLOW_DIFFUSION_CONST", "NEUTRON_FAST_DIFFUSION_RMS", "RINDEX", "ABSLENGTH", "RSLENGTH", ]
 }
 
+// From EGADS attenuation measurements
+// Compiled for RAT-PAC by Pierce Weatherly
+{
+name: "OPTICS",
+index: "water_egads_gd_sulfate_0p2",
+valid_begin : [0, 0],
+valid_end : [0, 0],
+// RINDEX not measured; copied from SNO HeavyWater
+RINDEX_option: "wavelength",
+RINDEX_value1: [200d, 210d, 220d, 230d, 240d, 250d, 260d, 270d, 280d, 290d, 300d, 310d, 320d, 330d, 340d, 350d, 360d, 370d, 380d, 390d, 400d, 410d, 420d, 430d, 440d, 450d, 460d, 470d, 480d, 490d, 500d, 510d, 520d, 530d, 540d, 550d, 560d, 570d, 580d, 590d, 600d, 610d, 620d, 630d, 640d, 650d, 660d, 670d, 680d, 690d, 700d, 710d, 720d, 730d, 740d, 750d, 760d, 770d, 780d, 790d, 800d, ],
+RINDEX_value2: [1.399d, 1.390d, 1.383d, 1.377d, 1.372d, 1.367d, 1.363d, 1.360d, 1.357d, 1.354d, 1.352d, 1.350d, 1.348d, 1.346d, 1.345d, 1.343d, 1.342d, 1.341d, 1.340d, 1.339d, 1.338d, 1.337d, 1.336d, 1.336d, 1.335d, 1.334d, 1.334d, 1.333d, 1.332d, 1.332d, 1.331d, 1.331d, 1.331d, 1.330d, 1.330d, 1.329d, 1.329d, 1.329d, 1.328d, 1.328d, 1.328d, 1.328d, 1.327d, 1.327d, 1.327d, 1.327d, 1.326d, 1.326d, 1.326d, 1.326d, 1.325d, 1.325d, 1.325d, 1.325d, 1.325d, 1.325d, 1.324d, 1.324d, 1.324d, 1.324d, 1.324d, ],
+ABSLENGTH_option: "wavelength",
+ABSLENGTH_value1: [337d, 375d, 405d, 445d, 473d, 532d, 595d, ],  // nm
+ABSLENGTH_value2: [145.6d2, 573.0d2, 102.5d3, 896.0d2, 776.7d2, 227.1d2, 64.2d2, ],  // mm
+OPSCATFRAC_option: "wavelength",
+OPSCATFRAC_value1: [337d, ],  // nm
+OPSCATFRAC_value2: [0.778d, ],
+PROPERTY_LIST: ["RINDEX", "ABSLENGTH", "OPSCATFRAC", ],
+}
 
 {
 name: "OPTICS",


### PR DESCRIPTION
Add a new water material with the attentuation measurements from EGADS
provided by Pierce Weatherly.

N.B. The refractive index wasn't measured for this water, so I've copied
`RINDEX` from the `HeavyWater` material in `SNO/OPTICS_SNO.ratdb`.

This has the optics, but the Gd-related physics needs to be checked. I seem
to recall Braidwood RAT doing something special to get Geant4 to handle
this correctly.

@nbarros I had to add Gd and S to `ELEMENTS.ratdb`, so the fall-back to
the NIST elements table must not be working right. Could you look into it?
