### PR TITLE
Add Q/T docs, fix Q/T bug.

### DIFF
--- a/doc/pmt.rst
+++ b/doc/pmt.rst
@@ -3,6 +3,28 @@ PMT Simulation
 
 RAT uses a custom PMT simulation extracted from GLG4Sim.
 
+Q/T Response
+````````````
+Gsim checks the database for single photoelectron charge and transit time PDFs 
+automatically for PMT models that are added to the geometry. These PDFs are 
+stored in tables named ``PMTCHARGE`` and ``PMTTRANSIT`` respectively, where the 
+index corresponds to a ``pmt_model`` field used in ``GEO`` tables. These PDFs
+are sampled whenever a photon is absorbed by the photocathode to create a 
+realistic Q/T response automatically for PMTs independent of any DAQ processor.
+If no tables are defined for a ``pmt_model`` the time defaults to approximately
+zero spread from photoelectron absorption time and the charge defaults to a
+phenomenological model used by MiniCLEAN.
+
+``PMTCHARGE`` fields:
+ * ``charge`` - "x" values of the charge PDF (arbitrary units)
+ * ``charge_prob`` - "y" values of the charge PDF (will be normalized)
+ 
+ 
+``PMTTRANSIT`` fields:
+ * ``cable_delay`` - constant offset applied to all PMTs of this model (nanoseconds)
+ * ``time`` - "x" values of the time PDF (nanoseconds)
+ * ``time_prob`` - "y" values of the time PDF (will be normalized)
+
 Dark Current
 ````````````
 

--- a/src/daq/PDFPMTCharge.cc
+++ b/src/daq/PDFPMTCharge.cc
@@ -9,10 +9,16 @@ namespace RAT {
 
 PDFPMTCharge::PDFPMTCharge(string pmt_model) {
     DBLinkPtr model = DB::Get()->GetLink("PMTCHARGE",pmt_model);
-    info << "Setting up PDF PMTCharge model for " << pmt_model << endl;
     
     fCharge = model->GetDArray("charge");
     fChargeProb = model->GetDArray("charge_prob");
+    
+    info << "Setting up PDF PMTCharge model for ";
+    if (pmt_model == "") { 
+        info << "DEFAULT" << endl;
+    } else {
+        info << pmt_model << endl;
+    }
     
     if (fCharge.size() != fChargeProb.size()) 
         Log::Die("PDFPMTCharge: charge and probability arrays of different length");
@@ -44,8 +50,8 @@ double PDFPMTCharge::PickCharge() const {
             return (rval - fChargeProbCumu[i-1])*(fCharge[i]-fCharge[i-1])/(fChargeProbCumu[i]-fChargeProbCumu[i-1]) + fCharge[i-1]; //linear interpolation
         }
     }
-    Log::Die("PDFPMTCharge::PickCharge: impossible condition encountered");
-    return 0.0;
+    info << "PDFPMTCharge::PickCharge: impossible condition encountered - returning highest defined charge" << endl;
+    return fCharge[fCharge.size()-1];
 }
 
 /** Value of charge PDF at charge q */

--- a/src/daq/PDFPMTCharge.cc
+++ b/src/daq/PDFPMTCharge.cc
@@ -20,7 +20,7 @@ PDFPMTCharge::PDFPMTCharge(string pmt_model) {
         Log::Die("PDFPMTCharge: cannot define a PDF with fewer than 2 points");
         
     double integral = 0.0;
-    fChargeProbCumu = vector<double>(fCharge.size()-1);
+    fChargeProbCumu = vector<double>(fCharge.size());
     fChargeProbCumu[0] = 0.0; 
     for (size_t i = 0; i < fCharge.size()-1; i++) {
         integral += (fCharge[i+1]-fCharge[i])*(fChargeProb[i]+fChargeProb[i+1])/2.0; //trapazoid integration
@@ -44,7 +44,7 @@ double PDFPMTCharge::PickCharge() const {
             return (rval - fChargeProbCumu[i-1])*(fCharge[i]-fCharge[i-1])/(fChargeProbCumu[i]-fChargeProbCumu[i-1]) + fCharge[i-1]; //linear interpolation
         }
     }
-    Log::Die("Sans cosmis ray bit flips, cannot get here");
+    Log::Die("PDFPMTCharge::PickCharge: impossible condition encountered");
     return 0.0;
 }
 

--- a/src/daq/PDFPMTTime.cc
+++ b/src/daq/PDFPMTTime.cc
@@ -12,11 +12,17 @@ namespace RAT {
 
 PDFPMTTime::PDFPMTTime(string pmt_model) {
     DBLinkPtr model = DB::Get()->GetLink("PMTTRANSIT",pmt_model);
-    info << "Setting up PDF PMTTime model for " << pmt_model << endl;
     
     fTime = model->GetDArray("time");
     fTimeProb = model->GetDArray("time_prob");
     fCableDelay = model->GetD("cable_delay");
+    
+    info << "Setting up PDF PMTTime model for ";
+    if (pmt_model == "") { 
+        info << "DEFAULT" << endl;
+    } else {
+        info << pmt_model << endl;
+    }
     
     if (fTime.size() != fTimeProb.size()) 
         Log::Die("PDFPMTTime: time and probability arrays of different length");
@@ -46,8 +52,8 @@ double PDFPMTTime::PickTime(double time) const {
             return fCableDelay + (rval - fTimeProbCumu[i-1])*(fTime[i]-fTime[i-1])/(fTimeProbCumu[i]-fTimeProbCumu[i-1]) + fTime[i-1]; //linear interpolation
         }
     }
-    Log::Die("PDFPMTTime::PickTime: impossible condition encountered");
-    return 0.0;
+    info << "PDFPMTTime::PickTime: impossible condition encountered - returning highest defined time" << endl;
+    return fTime[fTime.size()-1];
 }
   
 } // namespace RAT

--- a/src/daq/PDFPMTTime.cc
+++ b/src/daq/PDFPMTTime.cc
@@ -24,7 +24,7 @@ PDFPMTTime::PDFPMTTime(string pmt_model) {
         Log::Die("PDFPMTTime: cannot define a PDF with fewer than 2 points");
         
     double integral = 0.0;
-    fTimeProbCumu = vector<double>(fTime.size()-1);
+    fTimeProbCumu = vector<double>(fTime.size());
     fTimeProbCumu[0] = 0.0; 
     for (size_t i = 0; i < fTime.size()-1; i++) {
         integral += (fTime[i+1]-fTime[i])*(fTimeProb[i]+fTimeProb[i+1])/2.0; //trapazoid integration
@@ -46,7 +46,7 @@ double PDFPMTTime::PickTime(double time) const {
             return fCableDelay + (rval - fTimeProbCumu[i-1])*(fTime[i]-fTime[i-1])/(fTimeProbCumu[i]-fTimeProbCumu[i-1]) + fTime[i-1]; //linear interpolation
         }
     }
-    Log::Die("Sans cosmis ray bit flips, cannot get here");
+    Log::Die("PDFPMTTime::PickTime: impossible condition encountered");
     return 0.0;
 }
   


### PR DESCRIPTION
A vector was one index too short (changed indexing scheme without changing vector size), leading to an impossible condition (under normal circumstances) with a poor error message. Decided to have the error not kill RAT but rather print a warning and do the sensible thing since this could possibly (but unlikely) still be an issue if the RNG throws exactly 1.

Also adds some docs for the state of the Q/T simulation.