### PR TITLE
fix bug/misleading output in GLG4Scint

### DIFF
--- a/src/physics/GLG4Scint.cc
+++ b/src/physics/GLG4Scint.cc
@@ -792,9 +792,6 @@ void GLG4Scint::MyPhysicsTable::Entry::Build(
       G4cout << "\nWarning! Found a scintillator without LIGHT_YIELD parameter.";
       G4cout << "\nI will assume that for this material this parameter is ";
       G4cout << "implicit in the scintillation integral..." << G4endl;
-
-      // If no light yield, it's no scintillator
-      theScintillationLightVector=NULL;
     }
 
     // find the integral


### PR DESCRIPTION
Despite what it printed, GLG4Scint was modified to only produce
scintillation photons if the LIGHT_YIELD parameter was set for the
material.

This restores the default behavior: calculating the light yield from the
spectrum normalization and overriding with LIGHT_YIELD if it is
specified.

Thanks to @twongjirad for pointing this out!