### PR TITLE
Add regexfill position generator.

### DIFF
--- a/doc/generators.rst
+++ b/doc/generators.rst
@@ -277,7 +277,25 @@ fill
 
     /generator/pos/set x y z
 
-Events uniformly fill a logical volume containing the point (x, y, z) (mm).  The logical volumes are defined in the [source:RAT/trunk/data/simple.geo#latest geometry file].
+Events uniformly fill a physical volume containing the point (x, y, z) (mm).
+
+regexfill
+'''''''''
+
+::
+
+    /generator/pos/set volume_pattern
+    
+Events uniformly fill all physical volumes with names matching the `POSIX regular expression (regex) <https://en.wikipedia.org/wiki/Regular_expression#POSIX_basic_and_extended>`_ given as ``volume_pattern``. 
+In general volume names correspond to the index of ``GEO`` table entries, but complex geometry factories may generate other volumes as sub components, many volumes for arrays, or both.
+
+For a concrete example, this can be used to generate events in the wall (glass) of all PMTs built with a ``pmtarray`` type geometry factory. 
+If the index of the ``GEO`` table for the ``pmtarray`` was ``inner_pmts`` the PMTID number of the physical PMT would be appended to the volume name as it is created, so an appropriate regex would be ``inner_pmts[0-9]+`` ::
+
+    /generator/pos/set inner_pmts[0-9]+
+
+Note that the volume name is considered a match if the regex matches any part of the volume name, e.g. the regex ``mts1`` would match the volume name ``inner_pmts100``. 
+This can be avoided by using start ``^`` and end ``$`` of line characters when specifying a unique ``^volume$`` by name.
 
 fillshell
 '''''''''
@@ -301,7 +319,7 @@ paint
 
     /generator/pos/set x y z
 
-Events a distributed uniformly over the surface of the logical volume containing the point (x, y, z) (mm).  The logical volumes are defined in the [source:RAT/trunk/data/simple.geo#latest geometry file].
+Events a distributed uniformly over the surface of the logical volume containing the point (x, y, z) (mm).
 
 multipoint
 ''''''''''

--- a/src/gen/GLG4PrimaryGeneratorAction.cc
+++ b/src/gen/GLG4PrimaryGeneratorAction.cc
@@ -24,6 +24,7 @@
 #include "GLG4VertexGen.hh"            // for vertex generator
 #include "GLG4PosGen.hh"               // for global position generator
 #include <RAT/Factory.hh>
+#include <RAT/PosGen_RegexFill.hh>
 #include <RAT/PosGen_Line.hh>
 #include <RAT/PosGen_FillShell.hh>
 #include <RAT/PosGen_Radial.hh>
@@ -122,6 +123,9 @@ GLG4PrimaryGeneratorAction()
   RAT::GlobalFactory<GLG4PosGen>::Register("fill", 
 					   new RAT::Alloc<GLG4PosGen, 
 					   GLG4PosGen_Fill>);
+  RAT::GlobalFactory<GLG4PosGen>::Register("regexfill", 
+					   new RAT::Alloc<GLG4PosGen, 
+					   RAT::PosGen_RegexFill>);
   RAT::GlobalFactory<GLG4PosGen>::Register("multipoint", 
 					   new RAT::Alloc<GLG4PosGen, 
 					   RAT::PosGen_Multipoint>);

--- a/src/gen/PosGen_RegexFill.cc
+++ b/src/gen/PosGen_RegexFill.cc
@@ -1,0 +1,116 @@
+#include <RAT/PosGen_RegexFill.hh>
+#include <RAT/Log.hh>
+
+#include <G4VSolid.hh>
+#include <G4VoxelLimits.hh>
+#include <G4GeometryTolerance.hh>
+#include <G4TransportationManager.hh>
+#include <Randomize.hh>
+
+#include <sstream>
+
+using namespace std;
+
+namespace RAT {
+
+void PosGen_RegexFill::SetState(G4String regex) {
+    regex = trim(regex);
+
+    G4VPhysicalVolume *worldPhys = 
+        G4TransportationManager::GetTransportationManager()->
+        GetNavigatorForTracking()->
+        GetWorldVolume();
+        
+    G4LogicalVolume *worldLog = worldPhys->GetLogicalVolume();
+    
+    FindVolumes(worldLog,regex,fVolumes);
+    
+    if (fVolumes.size() == fVolumeCumu.size()) {
+        Log::Die("PosGen_RegexFill::SetState: the regex \"" + regex + "\" did not match any volumes!");
+    }
+    
+    fState += regex + " ";
+    
+    fVolumeCumu.resize(fVolumes.size());
+    fVolumeCumu[0] = fVolumes[0].solidVolume;
+    for (size_t i = 1; i < fVolumes.size(); i++) {
+        fVolumeCumu[i] = fVolumeCumu[i-1] + fVolumes[i].solidVolume;
+    }
+}
+
+void PosGen_RegexFill::FindVolumes(G4LogicalVolume *mother, G4String &regex, vector<FillVolume> &found) {
+    for (int i = 0; i < mother->GetNoDaughters(); i++) {
+        G4VPhysicalVolume *daughterPhys = mother->GetDaughter(i);
+        G4LogicalVolume *daughterLog = daughterPhys->GetLogicalVolume();
+        // this projects from daughter to mother coordinates
+        G4AffineTransform transform(daughterPhys->GetRotation(), daughterPhys->GetTranslation());
+        if (daughterPhys->GetName() == regex) { //daughterPhys matches the regular expression
+            found.resize(found.size()+1);
+            FillVolume &vol = found[found.size()-1];
+            
+            vol.phys = daughterPhys;
+            vol.log = daughterLog;
+            vol.transform = transform;
+            G4VSolid *solid = daughterLog->GetSolid();
+            vol.solidVolume = solid->GetCubicVolume(); //FIXME rumor has it that GetCubicVolume is terribly inaccurate
+            for (int j = 0; j < daughterLog->GetNoDaughters(); j++) {
+                G4VPhysicalVolume *grandPhys = daughterLog->GetDaughter(j);
+                G4AffineTransform grandTransform(grandPhys->GetRotation(), grandPhys->GetTranslation());
+                G4VSolid *grandSolid = grandPhys->GetLogicalVolume()->GetSolid();
+                vol.solidVolume -= grandSolid->GetCubicVolume();
+                vol.daughters.push_back(make_pair(grandSolid,grandTransform.Inverse()));
+            }
+            
+            G4VoxelLimits inf;
+            G4AffineTransform ident;
+            solid->CalculateExtent(kXAxis, inf, ident, vol.x0, vol.x1);
+            solid->CalculateExtent(kYAxis, inf, ident, vol.y0, vol.y1);
+            solid->CalculateExtent(kZAxis, inf, ident, vol.z0, vol.z1);
+            vol.boundVolume = (vol.x1-vol.x0)*(vol.y1-vol.y0)*(vol.z1-vol.z0);
+            
+        }
+        size_t j = found.size();
+        FindVolumes(daughterLog, regex, found);
+        for(; j < found.size(); j++) { //apply this mother->daughterPhys transform to all found matches
+            found[j].transform *= transform; 
+        }
+    }
+}
+
+G4String PosGen_RegexFill::GetState() const {
+    return fState;
+}
+
+void PosGen_RegexFill::GeneratePosition(G4ThreeVector& pos) {
+    double randVolume = G4UniformRand() * fVolumeCumu.back();
+    size_t volidx = 0;
+    for ( ; volidx < fVolumes.size(); volidx++) {
+        if (randVolume <= fVolumeCumu[volidx]) break;
+    }
+    FillVolume &vol = fVolumes[volidx];
+    G4VSolid *solid = vol.log->GetSolid();
+    //FIXME do we want to keep trying forever?
+    for (;;) {
+        //Solid works in "local" coordinates, so generate position, test, then project to global
+        G4ThreeVector trial(
+            vol.x0 + G4UniformRand() * (vol.x1 - vol.x0),
+            vol.y0 + G4UniformRand() * (vol.y1 - vol.y0),
+            vol.z0 + G4UniformRand() * (vol.z1 - vol.z0));
+        if (solid->Inside(trial)) { // inside the volume but maybe in a daughter
+            bool valid = true;
+            for (size_t j = 0; j < vol.daughters.size(); j++) {
+                if (vol.daughters[j].first->Inside(vol.daughters[j].second.TransformPoint(trial))) {
+                    valid = false; // point was inside a daughter
+                    break;
+                }
+            }
+            if (!valid) continue;
+            // Convert to global coordinates
+            pos = vol.transform.TransformPoint(trial);
+            return;
+        }
+    }
+}
+
+}
+

--- a/src/gen/PosGen_RegexFill.cc
+++ b/src/gen/PosGen_RegexFill.cc
@@ -7,14 +7,17 @@
 #include <G4TransportationManager.hh>
 #include <Randomize.hh>
 
-#include <sstream>
-
 using namespace std;
 
 namespace RAT {
 
 void PosGen_RegexFill::SetState(G4String regex) {
     regex = trim(regex);
+    
+    regex_t re;
+    if (regcomp(&re, regex, REG_EXTENDED|REG_NOSUB) != 0) {
+        Log::Die("PosGen_RegexFill::SetState: the string \"" + regex + "\" is not a valid regex!");
+    }
 
     G4VPhysicalVolume *worldPhys = 
         G4TransportationManager::GetTransportationManager()->
@@ -23,13 +26,21 @@ void PosGen_RegexFill::SetState(G4String regex) {
         
     G4LogicalVolume *worldLog = worldPhys->GetLogicalVolume();
     
-    FindVolumes(worldLog,regex,fVolumes);
+    FindVolumes(worldLog,&re,fVolumes);
+    
+    regfree(&re);
     
     if (fVolumes.size() == fVolumeCumu.size()) {
         Log::Die("PosGen_RegexFill::SetState: the regex \"" + regex + "\" did not match any volumes!");
     }
     
     fState += regex + " ";
+    
+    info << "PosGen_RegexFill::SetState: Adding volumes: ";
+    for (size_t i = fVolumeCumu.size(); i < fVolumes.size(); i++) {
+        info << fVolumes[i].phys->GetName() << ", ";
+    }
+    info << endl;
     
     fVolumeCumu.resize(fVolumes.size());
     fVolumeCumu[0] = fVolumes[0].solidVolume;
@@ -38,13 +49,13 @@ void PosGen_RegexFill::SetState(G4String regex) {
     }
 }
 
-void PosGen_RegexFill::FindVolumes(G4LogicalVolume *mother, G4String &regex, vector<FillVolume> &found) {
+void PosGen_RegexFill::FindVolumes(G4LogicalVolume *mother, regex_t *re, vector<FillVolume> &found) {
     for (int i = 0; i < mother->GetNoDaughters(); i++) {
         G4VPhysicalVolume *daughterPhys = mother->GetDaughter(i);
         G4LogicalVolume *daughterLog = daughterPhys->GetLogicalVolume();
         // this projects from daughter to mother coordinates
         G4AffineTransform transform(daughterPhys->GetRotation(), daughterPhys->GetTranslation());
-        if (daughterPhys->GetName() == regex) { //daughterPhys matches the regular expression
+        if (regexec(re, daughterPhys->GetName().c_str(), (size_t) 0, NULL, 0) == 0) { //daughterPhys matches the regular expression
             found.resize(found.size()+1);
             FillVolume &vol = found[found.size()-1];
             
@@ -52,15 +63,19 @@ void PosGen_RegexFill::FindVolumes(G4LogicalVolume *mother, G4String &regex, vec
             vol.log = daughterLog;
             vol.transform = transform;
             G4VSolid *solid = daughterLog->GetSolid();
-            vol.solidVolume = solid->GetCubicVolume(); //FIXME rumor has it that GetCubicVolume is terribly inaccurate
+            //volume of parent+daughters needs to be corrected
+            vol.solidVolume = GetVolume(solid);
             for (int j = 0; j < daughterLog->GetNoDaughters(); j++) {
                 G4VPhysicalVolume *grandPhys = daughterLog->GetDaughter(j);
                 G4AffineTransform grandTransform(grandPhys->GetRotation(), grandPhys->GetTranslation());
                 G4VSolid *grandSolid = grandPhys->GetLogicalVolume()->GetSolid();
-                vol.solidVolume -= grandSolid->GetCubicVolume();
+                //subtract off daughter volume from total volume
+                vol.solidVolume -= GetVolume(grandSolid);
+                //store granddaughter solid and tx from daughter->granddaughter frame
                 vol.daughters.push_back(make_pair(grandSolid,grandTransform.Inverse()));
             }
             
+            //use GEANT4 to calculate a bounding box of the solid in the solid's local coordinates
             G4VoxelLimits inf;
             G4AffineTransform ident;
             solid->CalculateExtent(kXAxis, inf, ident, vol.x0, vol.x1);
@@ -70,11 +85,22 @@ void PosGen_RegexFill::FindVolumes(G4LogicalVolume *mother, G4String &regex, vec
             
         }
         size_t j = found.size();
-        FindVolumes(daughterLog, regex, found);
+        FindVolumes(daughterLog, re, found);
         for(; j < found.size(); j++) { //apply this mother->daughterPhys transform to all found matches
             found[j].transform *= transform; 
         }
     }
+}
+
+std::map<G4VSolid*,double> PosGen_RegexFill::fSolidVolumes;
+
+double PosGen_RegexFill::GetVolume(G4VSolid *solid) {
+    if (!fSolidVolumes.count(solid)) {
+        //FIXME rumor has it GetCubicVolume is terribly inaccurate
+        //perhaps some higher accuracy monte-carlo integration is needed
+        fSolidVolumes[solid] = solid->GetCubicVolume();
+    }
+    return fSolidVolumes[solid];
 }
 
 G4String PosGen_RegexFill::GetState() const {

--- a/src/gen/PosGen_RegexFill.hh
+++ b/src/gen/PosGen_RegexFill.hh
@@ -1,0 +1,79 @@
+// Position generator to fill all volumes with names that match a regular 
+// expression. Excludes daughters unless they also match. Positions uniformly
+// distributed by volume among matched volumes.
+
+#ifndef __RAT_PosGen_RegexFill__
+#define __RAT_PosGen_RegexFill__
+
+#include <RAT/GLG4PosGen.hh>
+
+#include <G4VPhysicalVolume.hh>
+#include <G4LogicalVolume.hh>
+#include <G4AffineTransform.hh>
+#include <G4ThreeVector.hh>
+
+#include <vector>
+#include <utility>
+
+class G4VPhysicalVolume;
+class G4VSolid;
+
+namespace RAT {
+
+typedef struct {
+    // Logical volume representing found volume
+    G4LogicalVolume *log;
+    
+    // Physical volume that was found
+    G4VPhysicalVolume *phys;
+    
+    // Transformation from volume coordinates to global coordinates
+    G4AffineTransform transform;
+    
+    // Volume of solid and bounding box
+    double solidVolume, boundVolume;
+    
+    // Bounding box in volume coodinates
+    double x0,x1,y0,y1,z0,z1;
+    
+    // Pairs of Solids (in daughter coords) and transformations from volume to daughter coords
+    std::vector<std::pair<G4VSolid*,G4AffineTransform> > daughters;
+} FillVolume;
+
+class PosGen_RegexFill : public GLG4PosGen {
+    public:
+    
+        // Position generator to be called `regexfill`
+        PosGen_RegexFill(const char* dbname = "regexfill"): GLG4PosGen(dbname) { }
+        virtual ~PosGen_RegexFill() { }
+        
+        // Recursively traverses daughters of mother to find any volume names mathching the regex
+        // Adds found volumes to the `found` parameter and calculates all necessary fields of FillVolume
+        static void FindVolumes(G4LogicalVolume *mother, G4String &regex, std::vector<FillVolume> &found);
+        
+        // Generates a random position in a volume that matched a regex
+        // Positions are uniformly distributed (by volume) across all matches
+        // Positions exclude daughters of mathched volumes unless the daughter also matches
+        virtual void GeneratePosition(G4ThreeVector& pos);
+        
+        // Adds all volumes that match the regex to the fill list
+        virtual void SetState(G4String regex);
+        
+        // Returns a space separated list of regexes
+        virtual G4String GetState() const;
+        
+    protected:
+    
+        // Accumulates set regexes
+        std::string fState;
+        
+        // Volumes that matched the regexes
+        std::vector<FillVolume> fVolumes;
+        
+        // Stores the sum of the volume up to the requested index
+        std::vector<double> fVolumeCumu;
+};
+
+} // namespace RAT
+
+#endif


### PR DESCRIPTION
This position generator lets the user specify a set of volumes to be uniformly filled with events via a POSIX regular expression, making event generation very flexible. To generate events on the glass of PMTs built from a ```GEO``` table with index ```inner_pmts``` one would use the macro line

> /generator/pos/set inner_pmts[0-9]+

Which avoids the hack of generating events in a shared daughter volume of the PMTs that has the same name. This also serves as a uniform fill generator for specifying volumes by name, since the existing ```fill``` generator did not have that functionality. See docs for more details.