### PR TITLE
Reactor ibd

### DIFF
--- a/doc/generators.rst
+++ b/doc/generators.rst
@@ -207,6 +207,26 @@ ibd
 
 Inverse beta decay events caused by the interaction of a neutrino with a stationary proton.  The event is initialized with the products of the reaction, a positron and a free neutron.  The initial direction of the neutrino is along the (dir_x, dir_y, dir_z) vector.  The neutrino energy is drawn from the spectrum given in the [wiki:RATDB_IBD IBD table], and the positron direction distribution is weighted by the differential cross section of the interaction.
 
+reacibd
+'''
+
+::
+
+    /generator/vtx/set dir_x dir_y dir_z
+
+Inverse beta decay events caused by the interaction of a reactor neutrino with a stationary proton.  The initial energy of the neutrino for each event is selected from a probability density function dependent on the total neutrino flux from a reactor and the inverse beta-decay cross-section.  The initial direction of the neutrino is along the (dir_x, dir_y, dir_z) vector.  The positron direction is currently randomized relative to the neutrino's incident direction.
+
+The relative isotopic abundances of U235, U238, Pu239, and Pu241 can be controlled using macro commands:
+
+::
+
+    /generator/reacibd/U235 U235Amp  #Default is 0.496
+    /generator/reacibd/U238 U238Amp  #Default is 0.087
+    /generator/reacibd/Pu239 Pu239Amp  #Default is 0.391
+    /generator/reacibd/Pu241 Pu241Amp  #Default is 0.066
+
+The abundances should be provided for all four isotopes and should add to 1.  The addition of other isotopes and elements is currently not supported.
+
 es
 ''
 

--- a/mac/ReacIBDgen_Demo_Watchman.mac
+++ b/mac/ReacIBDgen_Demo_Watchman.mac
@@ -1,0 +1,31 @@
+/glg4debug/glg4param omit_muon_processes  1.0
+/glg4debug/glg4param omit_hadronic_processes 0 
+
+/rat/db/set DETECTOR experiment "Watchman"
+/rat/db/set DETECTOR geo_file "Watchman/Watchman.geo"
+
+/run/initialize
+
+# BEGIN EVENT LOOP
+/rat/proc simpledaq
+/rat/proc count
+/rat/procset update 10
+
+# Use IO.default_output_filename
+/rat/proclast outroot
+#END EVENT LOOP
+
+/generator/add combo reacibd:point 
+
+# Adjust reactor isotope contents: All four components'
+# ratios should, but do not have to, add to one.
+/generator/reacibd/U235 0.27
+/generator/reacibd/U238 0.26
+/generator/reacibd/Pu239 0.24
+/generator/reacibd/Pu241 0.23
+
+/generator/vtx/set 0 0 1.0
+/generator/pos/set 0 0 0
+
+/run/beamOn 100
+

--- a/src/cmd/ReacIBDgenMessenger.cc
+++ b/src/cmd/ReacIBDgenMessenger.cc
@@ -1,0 +1,91 @@
+// Rat::ReacIBDgenMessenger
+// 07-June-2015 Teal Pershing
+
+// Provide user commands that allow the user to change
+// the Reactor Isotope contents via the command line.
+
+#include <RAT/ReacIBDgenMessenger.hh>
+#include <RAT/ReacIBDgen.hh>
+
+#include <G4UIcommand.hh>
+#include <G4UIdirectory.hh>
+#include <G4UIcmdWithADouble.hh>
+#include <G4String.hh>
+
+namespace RAT {
+  ReacIBDgenMessenger::ReacIBDgenMessenger(ReacIBDgen* re) :
+    reacibdgen(re)
+  {
+    // Commands will be called in the mac with /generator/reacibd/
+    G4UIdirectory* dir = new G4UIdirectory("/generator/reacibd/");
+    dir->SetGuidance("Control the reactor isotope contents of the Reactor IBD generator");
+
+    U235AmpCmd = new G4UIcmdWithADouble("/generator/reacibd/U235", this);
+    U235AmpCmd->SetGuidance("Sets the fractional amount of U235 in the reactor of interest");
+    U235AmpCmd->SetParameterName("U235Amp",false);
+    U235AmpCmd->SetDefaultValue( reacibdgen->GetU235Amplitude() );
+
+
+    U238AmpCmd = new G4UIcmdWithADouble("/generator/reacibd/U238", this);
+    U238AmpCmd->SetGuidance("Sets the fractional amount of U238 in the reactor of interest");
+    U238AmpCmd->SetParameterName("U238Amp",false);
+    U238AmpCmd->SetDefaultValue( reacibdgen->GetU238Amplitude() );
+
+
+    Pu239AmpCmd = new G4UIcmdWithADouble("/generator/reacibd/Pu239", this);
+    Pu239AmpCmd->SetGuidance("Sets the fractional amount of Pu239 in the reactor of interest");
+    Pu239AmpCmd->SetParameterName("Pu239Amp",false);
+    Pu239AmpCmd->SetDefaultValue( reacibdgen->GetPu239Amplitude() );
+
+    Pu241AmpCmd = new G4UIcmdWithADouble("/generator/reacibd/Pu241", this);
+    Pu241AmpCmd->SetGuidance("Sets the fractional amount of Pu241 in the reactor of interest");
+    Pu241AmpCmd->SetParameterName("Pu241Amp",false);
+    Pu241AmpCmd->SetDefaultValue( reacibdgen->GetPu241Amplitude() );
+  }
+
+  ReacIBDgenMessenger::~ReacIBDgenMessenger() {;}
+
+  void ReacIBDgenMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
+  {
+    if ( command == U235AmpCmd )
+      {
+        G4double U235Ampl = U235AmpCmd->GetNewDoubleValue( newValue );
+        reacibdgen->SetU235Amplitude ( U235Ampl );
+      }
+    else if ( command == U238AmpCmd )
+      {
+        G4double U238Ampl = U238AmpCmd->GetNewDoubleValue( newValue );
+        reacibdgen->SetU238Amplitude ( U238Ampl );
+      }
+    else if ( command == Pu239AmpCmd )
+      {
+        G4double Pu239Ampl = Pu239AmpCmd->GetNewDoubleValue( newValue );
+        reacibdgen->SetPu239Amplitude ( Pu239Ampl );
+      }
+    else if ( command == Pu241AmpCmd )
+      {
+        G4double Pu241Ampl = Pu241AmpCmd->GetNewDoubleValue( newValue );
+        reacibdgen->SetPu241Amplitude ( Pu241Ampl );
+      }
+    else
+      {
+        G4cerr << "Error: Invalid ReacIBDgenMessenger \"set\" command" << G4endl;
+      }
+  }
+
+  G4String ReacIBDgenMessenger::GetCurrentValue(G4UIcommand* command)
+  {
+    if ( command == U235AmpCmd )
+	return U235AmpCmd->ConvertToString( reacibdgen->GetU235Amplitude() );
+    else if ( command == U238AmpCmd )
+	return U238AmpCmd->ConvertToString( reacibdgen->GetU238Amplitude() );
+    else if ( command == Pu239AmpCmd )
+	return Pu239AmpCmd->ConvertToString( reacibdgen->GetPu239Amplitude() );
+    else if ( command == Pu241AmpCmd )
+	return Pu241AmpCmd->ConvertToString( reacibdgen->GetPu241Amplitude() );
+
+    //Get here, you return an error.
+    return G4String("Error: Invalid ReacIBDgenMessenger \"get\" command");
+  }
+
+}  //namespace RAT

--- a/src/cmd/ReacIBDgenMessenger.hh
+++ b/src/cmd/ReacIBDgenMessenger.hh
@@ -1,0 +1,43 @@
+// RAT:: ReacIBDgenMessenger
+// 07-June-2015 Teal Pershing
+
+// Provides user commands that allow the user to change
+// The Reactor Isotope contents through the command line.
+
+#ifndef RAT_ReacIBDgenMessenger_hh
+#define RAT_ReacIBDgenMessenger_hh
+
+#include "G4UImessenger.hh"
+#include "G4String.hh"
+
+//Forward declarations
+class G4UIcommand;
+class G4UIcmdWithADouble;
+
+namespace RAT {
+
+  //Forward declarations within RAT namespace
+  class ReacIBDgen;
+
+  class ReacIBDgenMessenger: public G4UImessenger
+  {
+  public:
+    //ReacIBDgenMessenger(ReacIBDgen*);
+    ReacIBDgenMessenger(ReacIBDgen*);
+    ~ReacIBDgenMessenger();
+
+    void SetNewValue(G4UIcommand* command, G4String newValues);
+    G4String GetCurrentValue(G4UIcommand* command);
+
+  private:
+    ReacIBDgen* reacibdgen;
+
+    G4UIcmdWithADouble* U235AmpCmd;
+    G4UIcmdWithADouble* U238AmpCmd;
+    G4UIcmdWithADouble* Pu239AmpCmd;
+    G4UIcmdWithADouble* Pu241AmpCmd;
+  };
+
+} // namespace RAT
+
+#endif // RAT_ReacIBDgenMessenger_hh

--- a/src/core/Gsim.cc
+++ b/src/core/Gsim.cc
@@ -12,6 +12,7 @@
 #include <RAT/Factory.hh>
 #include <RAT/GLG4VertexGen.hh>
 #include <RAT/VertexGen_IBD.hh>
+#include <RAT/VertexGen_ReacIBD.hh>
 #include <RAT/Gen_LED.hh>
 #include <RAT/VertexGen_ES.hh>
 #include <RAT/VertexGen_Spectrum.hh>
@@ -19,6 +20,7 @@
 #include <RAT/Coincidence_Gen.hh>
 #include <RAT/VertexFile_Gen.hh>
 #include <RAT/CfGen.hh>
+#include <RAT/ReacIBDgen.hh>
 #include <RAT/EventInfo.hh>
 #include <RAT/TrackInfo.hh>
 #include <RAT/PrimaryVertexInformation.hh>
@@ -96,7 +98,10 @@ void Gsim::Init() {
   GlobalFactory<GLG4VertexGen>::Register("ibd",
                                          new Alloc<GLG4VertexGen,
                                          VertexGen_IBD>);
-  GlobalFactory<GLG4VertexGen>::Register("es",
+  GlobalFactory<GLG4VertexGen>::Register("reacibd",
+                                         new Alloc<GLG4VertexGen,
+                                         VertexGen_ReacIBD>);
+   GlobalFactory<GLG4VertexGen>::Register("es",
                                          new Alloc<GLG4VertexGen,
                                          VertexGen_ES>);
   GlobalFactory<GLG4VertexGen>::Register("spectrum",

--- a/src/gen/ReacIBDgen.cc
+++ b/src/gen/ReacIBDgen.cc
@@ -1,0 +1,353 @@
+#include <CLHEP/Units/PhysicalConstants.h>
+#include <CLHEP/Random/RandFlat.h>
+#include <CLHEP/Random/RandGeneral.h>
+
+#include <RAT/ReacIBDgenMessenger.hh>
+#include <RAT/ReacIBDgen.hh>
+#include <RAT/DB.hh>
+#include <fstream>
+#include <iostream>
+
+using namespace CLHEP;
+
+namespace RAT {
+
+//#define DEBUG
+
+// Additional constants
+const double DELTA = neutron_mass_c2 - proton_mass_c2;
+const double GFERMI = 1.16639e-11 / MeV / MeV;
+
+//We start with the Reactor Isotope components given in Marc Bergevin's original
+//IBDgenerator file
+
+const double ReacIBDgen::U235DEFAULT = 0.496;
+const double ReacIBDgen::U238DEFAULT = 0.087;
+const double ReacIBDgen::Pu239DEFAULT = 0.391;
+const double ReacIBDgen::Pu241DEFAULT = 0.066;
+ 
+ReacIBDgen::ReacIBDgen()
+{
+  //initialize your initial isotope values.
+  Reset();
+  // Get parameters from database
+  DBLinkPtr libd = DB::Get()->GetLink("IBD");
+
+  //initialize the messenger to adjust isotope parameters in mac files
+  messenger = new ReacIBDgenMessenger(this);
+
+  Emin = 1.806;  //CHANGED TO MATCH THE ENERGY RANGES IN MARC'S FILE FOR NOW
+  Emax = 14.000;
+
+}
+
+ReacIBDgen::~ReacIBDgen()
+{
+  //If there's no messenger adjustments, delete the messenger pointer.
+  if ( messenger != 0 )
+    {
+      delete messenger;
+      messenger = 0;
+    }
+}
+
+  
+void ReacIBDgen::GenEvent(const Hep3Vector &nu_dir,
+		      HepLorentzVector &neutrino,
+		      HepLorentzVector &positron,
+		      HepLorentzVector &neutron)
+{
+  float Enu, CosThetaLab;
+
+  // Pick energy of neutrino and relative direction of positron
+  GenInteraction(Enu, CosThetaLab);
+  
+  // Zero'th order approximation of positron quantities (infinite nucleon mass)
+  double E0 = Enu - DELTA;
+  double p0 = sqrt(E0*E0 - electron_mass_c2*electron_mass_c2); 
+  double v0 = p0/E0;
+
+  // First order correction of positron quantities for finite nucleon mass
+  double Ysquared = (DELTA*DELTA - electron_mass_c2*electron_mass_c2)/2;
+  double E1 = E0*(1 - Enu/proton_mass_c2*(1 - v0*CosThetaLab))
+               - Ysquared/proton_mass_c2;
+  double p1 = sqrt(E1*E1 - electron_mass_c2*electron_mass_c2);
+
+  // Compute nu 4-momentum
+  neutrino.setVect(nu_dir * Enu); // MeV (divide by c if need real units)
+  neutrino.setE(Enu);
+  
+  // Compute positron 4-momentum
+  Hep3Vector pos_momentum(p1*nu_dir);
+
+  // Rotation from nu direction to pos direction.
+  double theta = acos(CosThetaLab);
+  double phi = 2*pi*HepUniformRand();  // Random phi
+  Hep3Vector rotation_axis = nu_dir.orthogonal();
+  rotation_axis.rotate(phi, nu_dir);
+  pos_momentum.rotate(theta, rotation_axis);
+
+  positron.setVect(pos_momentum);
+  positron.setE(E1);
+  
+  // Compute neutron 4-momentum
+  neutron.setVect(neutrino.vect() - positron.vect());
+  neutron.setE(sqrt(neutron.vect().mag2() + neutron_mass_c2*neutron_mass_c2));  
+}
+
+
+
+
+void ReacIBDgen::GenInteraction(float &E, float &CosThetaLab)
+{
+    // Pick E from the reactor spectrum and cos(theta) uniformly
+
+    E = GetNuEnergy();
+    CosThetaLab = -1.0+2.0*HepUniformRand();
+  
+}
+
+void ReacIBDgen::SetU235Amplitude (double U235Am)
+{
+  if ((U235Am < 0.) || (U235Am > 1.))
+    {
+      G4cerr << "Set your U235 Amplitude between 0 and 1." << G4endl;
+      return;
+    }
+  U235Amp = U235Am;
+}
+
+void ReacIBDgen::Reset()
+{
+  SetU235Amplitude (U235DEFAULT);
+  SetU238Amplitude (U238DEFAULT);
+  SetPu239Amplitude (Pu239DEFAULT);
+  SetPu241Amplitude (Pu241DEFAULT);
+}
+
+void ReacIBDgen::SetU238Amplitude (double U238Am)
+{
+  if ((U238Am < 0.) || (U238Am > 1.))
+    {
+      G4cerr << "Set your U238 Amplitude between 0 and 1." << G4endl;
+      return;
+    }
+  U238Amp = U238Am;
+}
+
+void ReacIBDgen::SetPu239Amplitude (double Pu239Am)
+{
+  if ((Pu239Am < 0.) || (Pu239Am > 1.))
+    {
+      G4cerr << "Set your Pu239 Amplitude between 0 and 1." << G4endl;
+      return;
+    }
+  Pu239Amp = Pu239Am;
+}
+
+void ReacIBDgen::SetPu241Amplitude (double Pu241Am)
+{
+  if ((Pu241Am < 0.) || (Pu241Am > 1.))
+    {
+      G4cerr << "Set your Pu241 Amplitude between 0 and 1." << G4endl;
+      return;
+    }
+  Pu241Amp = Pu241Am;
+}
+
+
+float ReacIBDgen::GetNuEnergy(){
+      // This method of setting up probability densities as a function of 
+      // Energy is taken from the CfSource.cc file.
+
+      // setup the probability density as a function of energy
+
+      // Random generators according to probability densities.
+      static CLHEP::RandGeneral* fGenerate = 0;
+
+      static const float flow = Emin; static const float fhigh = Emax;
+
+      static bool first = true;
+      if (first)
+	{
+	  first = false;
+
+	  // In the original code, the probability densities used the
+	  // funlxp and funlux routines in CERNLIB to generate random
+	  // numbers.  The following code uses CLHEP to generate the
+	  // same "histograms" for the RandGeneral random-number
+	  // generator.
+
+	  const int probDensSize = 200;
+	  double fspace[probDensSize];
+
+	  // Find function values at bin centers.
+	  for ( int i=0; i != probDensSize; i++ )
+	    {
+	      float value = (float(i) + 0.5) * (fhigh - flow) / (float) probDensSize;
+	      fspace[i] = IBDESpectrum(flow + value);
+
+#ifdef DEBUG
+	      std::cout << "   i=" << i << " f="
+			<< fspace[i] << ","
+		        << std::endl;
+
+#endif
+
+#ifdef DEBUG
+	  	//Let's write the fspace prob. density function to a text file.
+	 	 std::ofstream fout("TheProbFunc.txt");
+	  	if(fout.is_open())
+	 	 {
+			std::cout << "Your file is open.  Let's put the probability density function into it..." << std::endl;
+			for(int i = 0; i < probDensSize; i++)
+			{
+				fout << i << " " << fspace[i] << std::endl;
+			}
+		 	fout.close();
+	 	 }
+#endif
+    	   }
+
+	  // Define random-number generators.  First argument has your
+	  // Array of probablility density values, second input has the
+	  // number of array elements.
+	  fGenerate = new CLHEP::RandGeneral(fspace,probDensSize);
+
+#ifdef DEBUG
+	  std::cout << " Random generator test (f):" << std::endl;
+	  for ( int i=0; i != 20; i++ )
+	    {
+	      std::cout << i << ": "
+			<< fGenerate->shoot() * (fhigh - flow) + flow << ", "
+		        << std::endl;
+	    }
+
+#endif
+	} 
+
+
+	  float nuE = fGenerate->shoot() * (fhigh - flow) + flow;
+
+#ifdef DEBUG
+	  std::cout << "Your generated neutrino energy is..." 
+		    << nuE
+		    << std::endl;
+#endif
+
+	  return nuE;
+}
+
+
+double ReacIBDgen::IBDESpectrum(float x){
+    //I have replaced the CrossSection function that lives in the original IBDgen
+    //With the cross section function given in the original source file from
+    //Marc Bergevin.
+  
+    double mElectron=0.511;  
+    double XC=CrossSection(x);
+    double EnergyVal = NuReacSpectrum(x)*XC*sqrt(XC*XC - mElectron*mElectron);
+    std::cout << EnergyVal << " and " << XC << std::endl;
+    return EnergyVal;
+  
+    //The final units output are in MeV
+  }
+
+
+double ReacIBDgen::CrossSection(float x){
+    
+    double mNeutron = 939.565378;
+    double mProton = 938.27;
+    double mElectron = 0.511;
+    double delta = mNeutron - mProton;
+    double A = 0.5;
+    double B = mNeutron*mNeutron;
+    double C = 4.0*mProton;
+    double D = delta+(delta*delta - mElectron*mElectron)/(2*mProton);
+    double E = mNeutron;
+
+    double XC = A*(sqrt(B - C*(D-x)) - E);
+  
+    return XC;  
+  }
+
+
+float ReacIBDgen::U235ReacSpectrum(const float& x){
+
+    // return the the reactor U235 neutrino flux contribution U235(x)
+    float N = 0.;
+   
+    // Use the current set Amplitude for the U235 contribution 
+    double C0 = GetU235Amplitude() ;
+    double C1=0.870;
+    double C2=0.160;
+    double C3=0.091;
+    //double C4=201.92;  //Defined in Marc Bergevin's original Reactor neutrino
+			 //generator.  Unsure of purpose
+
+    N = C0 * exp(C1 - C2*x - C3*x*x);
+
+    std::cout << "N " << N << std::endl;
+    return N;
+  }
+
+
+float ReacIBDgen::Pu239ReacSpectrum(const float& x){
+
+    // return the reactor Pu239 neutrino flux contribution Pu239(x)
+    float N = 0.;
+
+    double C0=GetPu239Amplitude();
+    double C1=0.896;
+    double C2=0.239;
+    double C3=0.0981;
+    //double C4=209.99;  //Defined in Marc's file; not sure of function
+    N = C0 * exp(C1 - C2*x - C3*x*x);
+
+    std::cout << "N " << N << std::endl;
+    return N;
+  }
+
+float ReacIBDgen::U238ReacSpectrum(const float& x){
+
+    // return the reactor U238 neutrino flux contribution U238(x)
+    float N = 0.;
+
+    double C0=GetU238Amplitude();
+    double C1=0.976;
+    double C2=0.162;
+    double C3=0.079;
+    //double C4=205.52;  //Defined in Marc's file; not sure of function
+    N = C0 * exp(C1 - C2*x - C3*x*x);
+
+    std::cout << "N " << N << std::endl;
+    return N;
+  }
+
+float ReacIBDgen::Pu241ReacSpectrum(const float& x){
+
+    // return the the reactor Pu241 Neutrino flux contribution Pu241(x)
+    float N = 0.;
+
+    double C0=GetPu241Amplitude();;
+    double C1=0.793;
+    double C2=0.080;
+    double C3=0.1085;
+    //double C4=213.60;  //Defined in Marc's file; not sure of function
+    N = C0 * exp(C1 - C2*x - C3*x*x);
+
+    std::cout << "N " << N << std::endl;
+    return N;
+  }
+
+float ReacIBDgen::NuReacSpectrum(const float& x){
+
+    // return the sum of the neutrino flux contributions from each reactor isotope
+    // for a given value x (energy in MeV)
+
+    float tot = U235ReacSpectrum(x) + Pu239ReacSpectrum(x) + U238ReacSpectrum(x) + Pu241ReacSpectrum(x);
+
+    return tot;
+  }
+
+} // namespace RAT

--- a/src/gen/ReacIBDgen.cc
+++ b/src/gen/ReacIBDgen.cc
@@ -330,7 +330,7 @@ float ReacIBDgen::Pu241ReacSpectrum(const float& x){
     // return the the reactor Pu241 Neutrino flux contribution Pu241(x)
     float N = 0.;
 
-    double C0=GetPu241Amplitude();;
+    double C0=GetPu241Amplitude();
     double C1=0.793;
     double C2=0.080;
     double C3=0.1085;

--- a/src/gen/ReacIBDgen.cc
+++ b/src/gen/ReacIBDgen.cc
@@ -247,7 +247,11 @@ double ReacIBDgen::IBDESpectrum(float x){
     double mElectron=0.511;  
     double XC=CrossSection(x);
     double EnergyVal = NuReacSpectrum(x)*XC*sqrt(XC*XC - mElectron*mElectron);
+
+#ifdef DEBUG
     std::cout << EnergyVal << " and " << XC << std::endl;
+#endif
+
     return EnergyVal;
   
     //The final units output are in MeV
@@ -287,7 +291,6 @@ float ReacIBDgen::U235ReacSpectrum(const float& x){
 
     N = C0 * exp(C1 - C2*x - C3*x*x);
 
-    std::cout << "N " << N << std::endl;
     return N;
   }
 
@@ -304,7 +307,6 @@ float ReacIBDgen::Pu239ReacSpectrum(const float& x){
     //double C4=209.99;  //Defined in Marc's file; not sure of function
     N = C0 * exp(C1 - C2*x - C3*x*x);
 
-    std::cout << "N " << N << std::endl;
     return N;
   }
 
@@ -320,7 +322,6 @@ float ReacIBDgen::U238ReacSpectrum(const float& x){
     //double C4=205.52;  //Defined in Marc's file; not sure of function
     N = C0 * exp(C1 - C2*x - C3*x*x);
 
-    std::cout << "N " << N << std::endl;
     return N;
   }
 
@@ -336,7 +337,6 @@ float ReacIBDgen::Pu241ReacSpectrum(const float& x){
     //double C4=213.60;  //Defined in Marc's file; not sure of function
     N = C0 * exp(C1 - C2*x - C3*x*x);
 
-    std::cout << "N " << N << std::endl;
     return N;
   }
 

--- a/src/gen/ReacIBDgen.hh
+++ b/src/gen/ReacIBDgen.hh
@@ -1,0 +1,105 @@
+#ifndef __RAT_ReacIBDgen__
+#define __RAT_ReacIBDgen__
+
+#include <RAT/LinearInterp.hh>
+#include <CLHEP/Random/Randomize.h>
+#include <G4ThreeVector.hh>
+#include <G4LorentzVector.hh>
+
+namespace RAT {
+
+//Initialize class for adding messages to mac files to adjust isotope params
+class ReacIBDgenMessenger;
+
+// Generate inverse beta decay event
+class ReacIBDgen {
+public:
+  ReacIBDgen();
+  ~ReacIBDgen();
+  
+  //Resets parameters to all default values
+  void Reset(); 
+
+  // Initialization of messenger object that lets user change parameters in mac files.
+  ReacIBDgenMessenger* messenger;
+
+  // Generate random event vectors
+  //    Pass in the neutrino direction (unit vector)
+  //    Returns 4-momentum vectors for neutrino and resulting positron
+  //    and neutron.  Neutrino energy and positron direction drawn from
+  //    GenInteraction() distribution.
+  void GenEvent(const G4ThreeVector &nu_dir,
+		G4LorentzVector &neutrino,
+		G4LorentzVector &positron,
+		G4LorentzVector &neutron);
+
+  // Generate random inverse beta decay interaction
+  //
+  //   Selects neutrino energy and cos(theta) of the produced
+  //   positron relative to neutrino direction.  They are pulled
+  //   from 2D distribution of reactor neutrinos which have interacted
+  //   with a proton, so both the incident flux, and the (relative) 
+  //   differential cross-section are factored in.
+  void GenInteraction(float &E, float &CosThetaLab);
+  
+  void SetU235Amplitude (double U235Am = U235DEFAULT);
+  void SetU238Amplitude (double U238Am = U238DEFAULT);
+  void SetPu239Amplitude (double Pu239Am = Pu239DEFAULT);
+  void SetPu241Amplitude (double Pu241Am = Pu241DEFAULT); 
+
+  // Total cross section for inverse beta decay
+  static double CrossSection(float x);
+
+
+  inline double GetU235Amplitude()   {return U235Amp;} ;
+  inline double GetU238Amplitude()   {return U238Amp;} ;
+  inline double GetPu239Amplitude()  {return Pu239Amp;} ;
+  inline double GetPu241Amplitude()  {return Pu241Amp;} ;
+
+  //Creates a probability density spectrum using the sum of the different
+  //reactor neutrino probability density spectrums as a function of energy.
+  //The function returns a random energy from the PDF based on the weighted
+  //probabilities.  This function uses the same method as the CfSource file
+  //to produce a random generator based on a probability density function.
+  float GetNuEnergy();
+
+  //Probability density functions of reactor neutrinos as a function of 
+  //energy.  Parametrization of fluxes for neutrinos from each reactor
+  //core isotope from "Determination of the Neutrino Mass Hierarchy at
+  //Intermediate Baseline", arxiv:0807.3203v2
+
+  //FIXME: Make the leading coefficients of these spectrums adjustable in
+  //the macro file that will call this generator.
+  float U235ReacSpectrum(const float& x);
+  float Pu239ReacSpectrum(const float& x);
+  float U238ReacSpectrum(const float& x);
+  float Pu241ReacSpectrum(const float& x);
+
+  //Sum of the reactor spectrums defined above.  the x value in this case is
+  //the energy of the neutrino, and the function would return the value of the
+  //PDF at that energy.
+  float NuReacSpectrum(const float& x);
+
+  //IBDEnergy which is a product of the above spectrums, the cross-section, and a
+  //square root factor with the cross section and electron mass.
+  double IBDESpectrum(float x);
+
+protected:
+  double Emax;
+  double Emin;
+  double U238Amp;
+  double U235Amp;
+  double Pu239Amp;
+  double Pu241Amp;
+
+  static const double U235DEFAULT;
+  static const double U238DEFAULT;
+  static const double Pu239DEFAULT;
+  static const double Pu241DEFAULT;
+
+};
+
+
+} // namespace RAT
+
+#endif

--- a/src/gen/VertexGen_ReacIBD.cc
+++ b/src/gen/VertexGen_ReacIBD.cc
@@ -1,0 +1,119 @@
+#include <globals.hh>
+#include <G4ParticleDefinition.hh>
+#include <Randomize.hh>
+#include <G4ParticleTable.hh>
+#include <G4ThreeVector.hh>
+#include <G4LorentzVector.hh>
+#include <G4PrimaryVertex.hh>
+#include <G4PrimaryParticle.hh>
+#include <G4Event.hh>
+
+#include <RAT/GLG4PosGen.hh>
+#include <sstream>
+#include <RAT/VertexGen_ReacIBD.hh>
+#include <RAT/ReacIBDgen.hh>
+#include <RAT/GLG4StringUtil.hh>
+
+namespace RAT {
+
+  
+VertexGen_ReacIBD::VertexGen_ReacIBD(const char *arg_dbname)
+  : GLG4VertexGen(arg_dbname), nu_dir(0.,0.,0.)
+{
+  nu = G4ParticleTable::GetParticleTable()->FindParticle("anti_nu_e");  
+  eplus = G4ParticleTable::GetParticleTable()->FindParticle("e+");  
+  n = G4ParticleTable::GetParticleTable()->FindParticle("neutron");  
+}
+
+VertexGen_ReacIBD::~VertexGen_ReacIBD()
+{
+  
+}
+
+void VertexGen_ReacIBD::
+GeneratePrimaryVertex(G4Event *argEvent,
+		      G4ThreeVector &dx,
+		      G4double dt)
+{
+  G4PrimaryVertex* vertex= new G4PrimaryVertex(dx, dt);
+  G4ThreeVector ev_nu_dir(nu_dir); // By default use specified direction
+  
+  if (ev_nu_dir.mag2() == 0.0) {
+    // Pick isotropic direction for incoming neutrino
+    double theta = acos(2.0 * G4UniformRand() - 1.0);
+    double phi = 2.0 * G4UniformRand() * pi;
+    ev_nu_dir.setRThetaPhi(1.0, theta, phi);
+  }
+
+  // -- Generate inverse beta decay interaction
+  G4LorentzVector mom_nu, mom_eplus, mom_n;
+
+  reacibd.GenEvent(ev_nu_dir, mom_nu, mom_eplus, mom_n);
+
+  // -- Create particles
+  
+  // positron
+  G4PrimaryParticle* eplus_particle =
+    new G4PrimaryParticle(eplus,              // particle code
+			  mom_eplus.px(),     // x component of momentum
+			  mom_eplus.py(),     // y component of momentum
+			  mom_eplus.pz());    // z component of momentum
+  eplus_particle->SetMass(eplus->GetPDGMass()); // Geant4 is silly.
+  vertex->SetPrimary( eplus_particle );  
+
+  // neutron
+  G4PrimaryParticle* n_particle =
+    new G4PrimaryParticle(n,                  // particle code
+			  mom_n.px(),         // x component of momentum
+			  mom_n.py(),         // y component of momentum
+			  mom_n.pz());        // z component of momentum
+  n_particle->SetMass(n->GetPDGMass()); // Geant4 is silly.
+  vertex->SetPrimary( n_particle );
+
+  argEvent->AddPrimaryVertex(vertex);
+}
+
+
+void VertexGen_ReacIBD::
+SetState(G4String newValues)
+{
+  newValues = util_strip_default(newValues); // from GLG4StringUtil
+  if (newValues.length() == 0) {
+    // print help and current state
+    G4cout << "Current state of this VertexGen_ReacIBD:\n"
+	   << " \"" << GetState() << "\"\n" << G4endl;
+    G4cout << "Format of argument to VertexGen_ReacIBD::SetState: \n"
+      " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
+      " where nu_dir is the initial direction of the reactor antineutrino.\n"
+      " Does not have to be normalized.  Set to \"0. 0. 0.\" for isotropic\n"
+      " neutrino direction."
+	   << G4endl;
+    return;
+  }
+
+  std::istringstream is(newValues.c_str());
+  double x, y, z;
+  is >> x >> y >> z;
+  if (is.fail())
+    return;
+
+  if ( x == 0. && y == 0. && z == 0. )
+    nu_dir.set(0., 0., 0.);
+  else
+    nu_dir = G4ThreeVector(x, y, z).unit();
+}
+
+
+G4String VertexGen_ReacIBD::
+GetState()
+{
+  std::ostringstream os;
+
+  os << nu_dir.x() << "\t" << nu_dir.y() << "\t" << nu_dir.z() << std::ends;
+
+  G4String rv(os.str());
+  return rv;
+}
+
+
+} // namespace RAT

--- a/src/gen/VertexGen_ReacIBD.hh
+++ b/src/gen/VertexGen_ReacIBD.hh
@@ -1,0 +1,43 @@
+#ifndef __RAT_VertexGen_ReacIBD__
+#define __RAT_VertexGen_ReacIBD__
+
+#include <RAT/GLG4VertexGen.hh>
+#include <RAT/ReacIBDgen.hh>
+
+/** vertex generator that can generate the products of a inverse
+    beta-decay reaction from a reactor anti-neutrino.  The direction
+    of the neutrino is supplied, and the energy and angle of the
+    produced positron and neutron are drawn from the distribution
+    produced by the differential cross-section and a reactor anti-neutrino
+    energy spectrum.
+*/
+
+namespace RAT {
+
+class VertexGen_ReacIBD : public GLG4VertexGen {
+public:
+  VertexGen_ReacIBD(const char *arg_dbname="ibd");
+  virtual ~VertexGen_ReacIBD();
+  virtual void GeneratePrimaryVertex( G4Event *argEvent,
+				      G4ThreeVector &dx,
+				      G4double dt);
+  // generates a primary vertex with given particle type, direction, energy,
+  // and consistent polarization.
+
+  virtual void SetState( G4String newValues );
+  // format: dir_x dir_y dir_z
+  // If dir_x==dir_y==dir_z==0, the directions are isotropic.
+
+  virtual G4String GetState();
+  // returns current state formatted as above
+
+private:
+  G4ParticleDefinition *nu, *n, *eplus;
+  ReacIBDgen reacibd;
+  G4ThreeVector nu_dir;
+};
+
+
+} // namespace RAT
+
+#endif


### PR DESCRIPTION
Pull request for the Reactor Inverse Beta Decay generator.  The generator selects an initial antineutrino energy based on the parameterized neutrino flux from reactors.  Using this energy, the positron and neutron energies are found and generated.  The distribution that antineutrino energies are chosen from can also be modified by manually inputting reactor isotopic contents as shown in the ReacIBD_demo_watchman.mac file.  A read-me must still be written for usage of the generator.

~Teal Pershing