### PR TITLE
Use evaluated thermal neutron scattering data

### DIFF
--- a/data/ELEMENTS.ratdb
+++ b/data/ELEMENTS.ratdb
@@ -403,3 +403,71 @@ z: 39,
 a:88.9,
 }
 
+{
+name: "ELEMENT",
+index: "TS_H_of_Water",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+
+SYMBOL: "H",
+z: 1,
+a: 1.008,
+}
+
+{
+name: "ELEMENT",
+index: "TS_H_of_Polyethylene",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+
+SYMBOL: "H",
+z: 1,
+a: 1.008,
+}
+
+{
+name: "ELEMENT",
+index: "TS_D_of_Heavy_Water",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+
+SYMBOL: "D",
+z: 1,
+a: 2.0144,
+isotopes: [2],
+isotopes_frac: [1.0],
+}
+
+{
+name: "ELEMENT",
+index: "TS_Aluminium_Metal",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+
+SYMBOL: "Al",
+z: 13,
+a: 26.98,
+}
+
+{
+name: "ELEMENT",
+index: "TS_C_of_Graphite",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+
+SYMBOL: "C",
+z: 6,
+a: 12.01,
+
+}
+
+{
+name: "ELEMENT",
+index: "TS_Iron_Metal",
+valid_begin: [0, 0],
+valid_end: [0, 0],
+
+SYMBOL: "Fe",
+z: 26,
+a: 55.845,
+}

--- a/data/MATERIALS.ratdb
+++ b/data/MATERIALS.ratdb
@@ -37,7 +37,7 @@ valid_end : [0, 0],
 density: 1.0,
 nelements: 2, 
 nmaterials: 0,
-elements: ["Hydrogen", "Oxygen",],
+elements: ["TS_H_of_Water", "Oxygen",],
 elemprop: [0.1119, 0.8881],
 }
 
@@ -50,7 +50,7 @@ valid_end : [0, 0],
 density: 2.7,
 nelements: 1,
 nmaterials: 0,
-elements: ["Aluminum"],
+elements: ["TS_Aluminium_Metal"],
 elemprop: [1.0],
 }
 
@@ -76,7 +76,7 @@ valid_end : [0, 0],
 density: 7.87,
 nelements: 1,
 nmaterials: 0,
-elements: ["Iron"],
+elements: ["TS_Iron_Metal"],
 elemprop: [1.0],
 }
 
@@ -88,7 +88,7 @@ valid_end : [0, 0],
 density: 7.87,
 nelements: 3,
 nmaterials: 0,
-elements: ["Iron", "Chromium","Nitrogen"],
+elements: ["TS_Iron_Metal", "Chromium","Nitrogen"],
 elemprop: [0.71, 0.19, 0.1],
 }
 
@@ -104,7 +104,7 @@ nelements: 10,
 nmaterials: 0,
 elements: [
   "Carbon",     "Manganese",  "Silicon", "Chromium", "Nickel",
-  "Molybdenum", "Phosphorus", "Sulphur", "Nitrogen", "Iron"
+  "Molybdenum", "Phosphorus", "Sulphur", "Nitrogen", "TS_Iron_Metal"
 ],
 elemprop:[
   0.00030, 0.0200,  0.0075,  0.1800, 0.1400, 
@@ -773,7 +773,7 @@ valid_end : [0, 0],
 density: 1.397, // from NIST database
 nelements: 3,
 nmaterials: 0,
-elements: ["Hydrogen", "Carbon","Oxygen"],
+elements: ["TS_H_of_Polyethylene", "Carbon","Oxygen"],
 elemprop: [0.042, 0.625, 0.333],
 }
 
@@ -785,7 +785,7 @@ valid_end : [0, 0],
 density: 1.35, // from NIST database
 nelements: 3,
 nmaterials: 0,
-elements: ["Hydrogen", "Carbon","Oxygen"],
+elements: ["TS_H_of_Polyethylene", "Carbon","Oxygen"],
 elemprop: [0.0416, 0.6942, 0.2642],
 }
 
@@ -986,7 +986,7 @@ valid_end : [0, 0],
 density: 1.0, 
 nelements: 4,
 nmaterials: 0,
-elements: ["Hydrogen", "Oxygen", "Sodium", "Chlorine",],
+elements: ["TS_H_of_Water", "Oxygen", "Sodium", "Chlorine",],
 elemprop: [0.111372, 0.883628,0.001967,0.003033],
 }
 

--- a/src/geo/Materials.cc
+++ b/src/geo/Materials.cc
@@ -93,7 +93,7 @@ void Materials::LoadOpticalSurfaces() {
         }
       }
       catch (DBNotFoundError& e) {}
-      
+
       try {
         std::string name = iv->second->GetS("type");
         if (opticalSurfaceTypes.find(name) != opticalSurfaceTypes.end()) {
@@ -178,7 +178,7 @@ void Materials::ConstructMaterials() {
       G4cout << "Materials error: Could not construct elements" << G4endl;
     }
   }
-  
+
   // === Material ===============================================
 
   vector<string> queue;
@@ -277,7 +277,7 @@ bool Materials::BuildMaterial(string namedb, DBLinkPtr table) {
     G4cout << "Materials: Material read error" << G4endl;
     return false;
   }
-    
+
   try {
     string stringstate = table->GetS("state");
     if (stringstate == "gas")
@@ -290,12 +290,13 @@ bool Materials::BuildMaterial(string namedb, DBLinkPtr table) {
   catch (DBNotFoundError &e) {
     state = kStateUndefined;
   }
-      
+
   try {
     temperature = table->GetD("temperature");
   }
   catch (DBNotFoundError &e) {
-    temperature = CLHEP::STP_Temperature;
+    // Use "room temperature" (25 degrees Celsius) as the default
+    temperature = 298.15*CLHEP::kelvin;
   }
 
   try {
@@ -305,7 +306,7 @@ bool Materials::BuildMaterial(string namedb, DBLinkPtr table) {
     pressure = CLHEP::STP_Pressure;
   }
 
-  G4Material* tempptr = 
+  G4Material* tempptr =
     new G4Material(namedb, densitydb, nelementsdb + nmaterialsdb,
                    state, temperature, pressure);
 
@@ -378,10 +379,10 @@ bool Materials::BuildMaterial(string namedb, DBLinkPtr table) {
       else {
         G4MaterialTable* tmp_table =
           (G4MaterialTable*) tempptr->GetMaterialTable();
-        std::vector<G4Material*>::iterator it = tmp_table->begin() + tempptr->GetIndex(); 
+        std::vector<G4Material*>::iterator it = tmp_table->begin() + tempptr->GetIndex();
         delete tempptr;
-        tmp_table->erase(it); 
-        return false; 
+        tmp_table->erase(it);
+        return false;
       }
     }
   }
@@ -526,7 +527,7 @@ void Materials::LoadOptics() {
   for (DBLinkGroup::iterator iv=mats.begin(); iv!=mats.end(); iv++) {
     std::string name = iv->first;
     G4cout << "Loading optics: " << name << G4endl;
-    
+
     G4Material* material = G4Material::GetMaterial(name);
     if (material == NULL) {
       G4cout << "While loading optics in Materials, "

--- a/src/physics/PhysicsList.cc
+++ b/src/physics/PhysicsList.cc
@@ -43,22 +43,19 @@ void PhysicsList::ConstructProcess() {
   EnableThermalNeutronScattering();
 }
 
-// Add thermal neutron scattering to this physics list.
-// Based on the technique shown here: http://tinyurl.com/hszjtln
-// See http://tinyurl.com/zx53kjq for more details.
 void PhysicsList::EnableThermalNeutronScattering() {
 
   // Get the particle definition for neutrons
   G4ParticleDefinition* n_definition = G4Neutron::Definition();
 
   // Get the elastic scattering process used for neutrons
-  G4HadronicProcess* n_elastic_process = nullptr;
+  G4HadronicProcess* n_elastic_process = NULL;
   G4ProcessVector* proc_vec = n_definition->GetProcessManager()
     ->GetProcessList();
-  for (size_t i = 0; i < proc_vec->size(); ++i) {
+  for (int i = 0; i < proc_vec->size(); i++) {
     G4VProcess* proc = proc_vec->operator[](i);
-    if (proc->GetProcessSubType() == G4HadronicProcessType::fHadronElastic
-      && proc->GetProcessType() == G4ProcessType::fHadronic)
+    if (proc->GetProcessSubType() == fHadronElastic
+      && proc->GetProcessType() == fHadronic)
     {
       n_elastic_process = dynamic_cast<G4HadronicProcess*>(proc);
       break;

--- a/src/physics/PhysicsList.cc
+++ b/src/physics/PhysicsList.cc
@@ -1,11 +1,18 @@
 #include <string>
 #include <stdexcept>
 #include <Shielding.hh>
+#include <G4Cerenkov.hh>
 #include <G4FastSimulationManagerProcess.hh>
+#include <G4HadronicInteractionRegistry.hh>
+#include <G4HadronicProcess.hh>
+#include <G4HadronicProcessType.hh>
+#include <G4Neutron.hh>
+#include <G4NeutronHPThermalScattering.hh>
+#include <G4NeutronHPThermalScatteringData.hh>
 #include <G4OpticalPhoton.hh>
 #include <G4ParticleDefinition.hh>
 #include <G4ProcessManager.hh>
-#include <G4Cerenkov.hh>
+#include <G4ProcessVector.hh>
 #include <G4OpBoundaryProcess.hh>
 #include <G4RunManager.hh>
 #include <RAT/GLG4OpAttenuation.hh>
@@ -33,6 +40,55 @@ void PhysicsList::ConstructProcess() {
   AddParameterization();
   Shielding::ConstructProcess();
   ConstructOpticalProcesses();
+  EnableThermalNeutronScattering();
+}
+
+// Add thermal neutron scattering to this physics list.
+// Based on the technique shown here: http://tinyurl.com/hszjtln
+// See http://tinyurl.com/zx53kjq for more details.
+void PhysicsList::EnableThermalNeutronScattering() {
+
+  // Get the particle definition for neutrons
+  G4ParticleDefinition* n_definition = G4Neutron::Definition();
+
+  // Get the elastic scattering process used for neutrons
+  G4HadronicProcess* n_elastic_process = nullptr;
+  G4ProcessVector* proc_vec = n_definition->GetProcessManager()
+    ->GetProcessList();
+  for (size_t i = 0; i < proc_vec->size(); ++i) {
+    G4VProcess* proc = proc_vec->operator[](i);
+    if (proc->GetProcessSubType() == G4HadronicProcessType::fHadronElastic
+      && proc->GetProcessType() == G4ProcessType::fHadronic)
+    {
+      n_elastic_process = dynamic_cast<G4HadronicProcess*>(proc);
+      break;
+    }
+  }
+  if (!n_elastic_process) {
+    std::cerr << "PhysicsList::EnableThermalNeutronScattering: "
+      << " couldn't find hadron elastic scattering process.\n";
+    throw std::runtime_error(std::string("Missing") + " hadron elastic"
+      + " scattering process in PhysicsList");
+  }
+
+  // Get the "regular" neutron HP elastic scattering model
+  G4HadronicInteraction* n_elastic_hp
+    = G4HadronicInteractionRegistry::Instance()->FindModel("NeutronHPElastic");
+  if (!n_elastic_hp) {
+    std::cerr << "PhysicsList::EnableThermalNeutronScattering: "
+      << " couldn't find high-precision neutron elastic"
+      << " scattering interaction.\n";
+    throw std::runtime_error(std::string("Missing") + " NeutronHPElastic"
+      + " scattering interaction in PhysicsList");
+  }
+
+  // Exclude the thermal scattering region (below 4 eV) from the "regular"
+  // elastic scattering model
+  n_elastic_hp->SetMinEnergy(4.*eV);
+
+  // Use the more detailed HP thermal scattering treatment below 4 eV instead
+  n_elastic_process->RegisterMe(new G4NeutronHPThermalScattering);
+  n_elastic_process->AddDataSet(new G4NeutronHPThermalScatteringData);
 }
 
 void PhysicsList::SetOpWLSModel(std::string model) {

--- a/src/physics/PhysicsList.hh
+++ b/src/physics/PhysicsList.hh
@@ -39,6 +39,10 @@ private:
   // Construct and register optical processes
   void ConstructOpticalProcesses();
 
+  // Adjust the neutron elastic scattering process so that it uses a more
+  // precise treatment in the thermal region (below 4 eV)
+  void EnableThermalNeutronScattering();
+
   // Register opticalphotons with the PMT G4FastSimulationManagerProcess
   void AddParameterization();
 

--- a/src/physics/PhysicsList.hh
+++ b/src/physics/PhysicsList.hh
@@ -41,6 +41,9 @@ private:
 
   // Adjust the neutron elastic scattering process so that it uses a more
   // precise treatment in the thermal region (below 4 eV)
+  // Based on the technique shown here: http://hypernews.slac.stanford.edu/HyperNews/geant4/get/hadronprocess/1471.html
+  // See https://indico.cern.ch/event/245281/contributions/1564676/attachments/420136/583408/thermal_physics_validation_argarcia.pdf
+  // for more details.
   void EnableThermalNeutronScattering();
 
   // Register opticalphotons with the PMT G4FastSimulationManagerProcess


### PR DESCRIPTION
The RAT-PAC PhysicsList class inherits from Geant4's Shielding physics list. While this list uses high-precision neutron data (based on ENDF format cross sections) below 20 MeV, it does not use thermal scattering matrix data available via the [G4ParticleHPThermalScattering](http://hurel.hanyang.ac.kr/Geant4/Doxygen/10.01/html/d4/d08/class_g4_particle_h_p_thermal_scattering.html) class.

The scattering matrix approach provides a more realistic treatment of thermal neutron transport below 4 eV in Geant4. It accounts for thermal motion and chemical binding effects that become important for thermal neutrons. Evaluated scattering matrix data are only available for a few elements (those listed in [G4ParticleHPThermalScatteringNames.cc](http://hurel.hanyang.ac.kr/Geant4/Doxygen/10.01/html/d9/d6d/_g4_particle_h_p_thermal_scattering_names_8cc_source.html)). When such data are not available, Geant4 will revert to a free gas model for thermal scattering.

For a bit more information about the relevant physics and the Geant4 implementation, please consult [this presentation](http://tinyurl.com/zx53kjq).

In this pull request, I have updated the PhysicsList class and the RAT DB files to use Geant4's thermal neutron scattering data where available. The changes to the "water" materials in particular should produce a more accurate treatment of thermal neutron capture for RAT-PAC.
