### PR TITLE
Fix calculation of neutron momentum components in CfSource.cc

### DIFF
--- a/src/gen/CfSource.cc
+++ b/src/gen/CfSource.cc
@@ -146,9 +146,18 @@ namespace RAT {
 	  double phi = CLHEP::RandFlat::shoot(0.,M_PI);
 	  double cosTheta = CLHEP::RandFlat::shoot(-1.,1.);
 	  double sinTheta = sqrt( 1. - cosTheta*cosTheta );
-	  double px = neutronKE * sinTheta * cos(phi);
-	  double py = neutronKE * sinTheta * sin(phi);
-	  double pz = neutronKE * cosTheta;
+
+	  // Compute the momentum squared. If it comes out negative
+	  // due to roundoff errors, just set it equal to zero. This
+	  // prevents problems when we take the square root below.
+	  double neutronP2 = std::max(0., energy*energy
+	    - massNeutron*massNeutron);
+
+	  // Compute the momentum components
+	  double neutronP = std::sqrt(neutronP2);
+	  double px = neutronP * sinTheta * cos(phi);
+	  double py = neutronP * sinTheta * sin(phi);
+	  double pz = neutronP * cosTheta;
 #ifdef DEBUG
 	  std::cout << "CfSource::CfSource() - neutron energy " 
 		    << nn << " = " << energy


### PR DESCRIPTION
See issue #55. The problem mentioned there occurs because `CfSource.cc` on lines 149-151 calculates the components of the neutron momenta using the kinetic energy instead of the momentum:
```
      double px = neutronKE * sinTheta * cos(phi);
      double py = neutronKE * sinTheta * sin(phi);
      double pz = neutronKE * cosTheta;
```