### PR TITLE
Fixed SetReadTree method in RunStore.cc.

### DIFF
--- a/src/ds/RunStore.cc
+++ b/src/ds/RunStore.cc
@@ -35,7 +35,8 @@ Run* RunStore::InstanceGetRun(int run) {
   
   // Scan quickly through tree
   //fReadTree->SetBranchStatus("*", 0); //for some reason this segfaults
-  fReadTree->SetBranchStatus("runID", 1);
+  //fReadTree->SetBranchStatus("runID", 1);
+  fReadTree->SetBranchStatus("id", 1);
   
   // Have to reset branch address after calling SetBranchStatus
   // in case fReadTree is TChain


### PR DESCRIPTION
Change incorrect data structure variable name "runID" to "id" to allow run-level information to be extracted from output ROOT files.