### PR TITLE
Resolve log buffer memory issue

### DIFF
--- a/src/core/Log.hh
+++ b/src/core/Log.hh
@@ -65,6 +65,12 @@ Log::Die("Could not open " + filename + " for input.");
  *
  *  Works like standard assert(), but lets you print something to the user
  *  before dying if condition fails.
+ *
+ *  REVISION HISTORY
+ *    2017-06-08: M Smiley - Resolve memory leak induced by
+ *                           keeping log in buffer during simulation
+ *
+ *
  */
 
 #ifndef __RAT_Log__
@@ -106,11 +112,9 @@ public:
    *  @param  _filename  Name of log file to open for writing.
    *  @param  display    Verbosity level for display on screen
    *  @param  log        Verbosity level for writing to log file.
-   *  @param  use_buffer Keep copy of log in memory buffer?
    */
   static bool Init(std::string _filename, 
-		   Level display=INFO, Level log=DETAIL,
-		   bool use_buffer=true);
+		   Level display=INFO, Level log=DETAIL);
 
   /** Get the current verbosity level for display on screen. */
   static int GetDisplayLevel() { return display_level; };
@@ -133,7 +137,7 @@ public:
   static void Assert(bool condition, std::string message, int return_code=1);
 
   /** Return reference to string containing entire log from this session */
-  static const std::string &GetLogBuffer() { return logbuffer.get_string(); };
+  static const std::string GetLogBuffer();
 
   /** Add macro commands to buffer.  Don't forget newlines! */
   static void AddMacro(const std::string &contents) {
@@ -224,8 +228,6 @@ protected:
 
   static std::string filename;   /**< Name of log file. */
   static oftext logfile;         /**< Log file object */
-  static ostext logbuffer;         /**< In-memory copy of logfile object */
-  static bool use_buffer;        /**< Set if log file should be saved in memory */
   static int display_level;      /**< Current display verbosity */
   static int log_level;          /**< Current log file verbsoity */
   


### PR DESCRIPTION
Remove unnecessary buffer for log to cut down on memory use, especially relevant for long and complex simulations.