### PR TITLE
Fix compilation on macOS

### DIFF
--- a/config/ARCH.macosx64
+++ b/config/ARCH.macosx64
@@ -19,4 +19,5 @@ if len(parts) >= 2 and int(parts[1]) >= 8:
 
 arch['Xm'].update( { 'CPPPATH' : '/sw/include',
                      'LIBPATH' : '/sw/lib' }    )
+arch['default']['CXXFLAGS'] += ['-Wno-reserved-id-macro', '-Wno-keyword-macro']
 Return('arch')

--- a/src/physics/PhysicsList.cc
+++ b/src/physics/PhysicsList.cc
@@ -23,6 +23,9 @@
 #include <RAT/PhysicsListMessenger.hh>
 #include <RAT/PhysicsList.hh>
 
+template<>
+G4VUPLData* G4VUPLSplitter<G4VUPLData>::offset = NULL;
+
 namespace RAT {
 
 PhysicsList::PhysicsList() : Shielding(), wlsModel(NULL) {


### PR DESCRIPTION
* Fix a `-Wundefined-var-template` in `RAT::PhysicsList` by adding an   explicit instantiation.
* Disable a clang warning that prevents the public/private "jailbreak" trick

Tested on:
* Apple LLVM version 9.0.0 (clang-900.0.39.2) (macOS Sierra 10.12.6)
* gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3) (Ubuntu 14.04.4 LTS)

Closes #59